### PR TITLE
Adds Platforms requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 [Why the software does things the way it does and why it was designed in the first place. What problems are solved by it. Links to publications and comparisons to similar software.]
 
+# Platforms
+- linux
+- arm64
+- v8
+
 # Minimal System Requirements
 - 8GB RAM
 - 60GB Storage


### PR DESCRIPTION
I tried to run the container (**docker compose up -d**) on my MacBook Pro Apple M2 Max chip and I got the following errors multiple times:
`✔ Container regulondb12_app-flask Created0.0s 64) does not match the detected host platform (linux/arm64/v8) a`
`✔ Container regulondb12_app-react Recreated0.1s`
 
And then this _final_ error messages:
```
! web The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested   0.0s
 ✔ Container regulondb12_app-nginx  Recreated0.1s
```

``` 
! proxy The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested 0.0s
```

This makes me think that the image/docker configuration is not currently supporting this type of processor. **It should be added in the README**.

The platforms added on the Commit are the ones mentioned that **can be used**, on the **error messages**.