### PR TITLE
Adds NOTE fix for install error

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,6 +14,10 @@ Locate the file in a terminal and use the following command to get the images re
 docker compose pull
 ```
 
+> **_NOTE:_**  If you get the error *no configuration file provided: not found* add the file flag -f with the name **you saved** the docker compose file with, to the command.
+>> docker compose **-f .\regulondbdata-docker-compose.yml** pull
+
+
 When the download is compleated, use the following command to start the RegulonDB instance:
 ```bash
 docker compose up -d

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 [Why the software does things the way it does and why it was designed in the first place. What problems are solved by it. Links to publications and comparisons to similar software.]
 
+# Platforms
+- linux
+- arm64
+- v8
+
 # Minimal System Requirements
 - 8GB RAM
 - 60GB Storage


### PR DESCRIPTION
### CHANGES
A NOTE on how to solve a possible installation error was added.

### EXPLANATION
When saving the docker-compose.yml file **with a different name** (like regulondbdata-docker-compose.yml) docker compose pull / docker compose up -d will not work, and there will be a _no configuration file provided: not found_ error.

Adding a file flag -f following with the name of the file fixes the problem. Example:
```
docker compose -f .\regulondbdata-docker-compose.yml pull
```

